### PR TITLE
Fixed hidden extension and system file handling

### DIFF
--- a/src/modules/peek/PeekFileUtils/FileTypeUtils.cpp
+++ b/src/modules/peek/PeekFileUtils/FileTypeUtils.cpp
@@ -3,6 +3,18 @@
 
 namespace FileUtils
 {
+    bool IsViewable(String const& filepath)
+    {
+        LPCWSTR path = filepath.c_str();
+        DWORD attrib = GetFileAttributes(path);
+        if (attrib & FILE_ATTRIBUTE_HIDDEN && attrib & FILE_ATTRIBUTE_SYSTEM)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
     bool IsMedia(std::wstring const& extension)
     {
         return IsImage(extension) || IsVideo(extension);

--- a/src/modules/peek/PeekFileUtils/FileTypeUtils.h
+++ b/src/modules/peek/PeekFileUtils/FileTypeUtils.h
@@ -6,6 +6,8 @@
 
 namespace FileUtils
 {
+    bool IsViewable(String const& filepath);
+
     bool IsMedia(String const& extension);
     bool IsImage(String const& extension);
     bool IsVideo(String const& extension);

--- a/src/modules/peek/PeekFileUtils/FileUtils.cpp
+++ b/src/modules/peek/PeekFileUtils/FileUtils.cpp
@@ -74,13 +74,11 @@ namespace FileUtils
                                                             if (SUCCEEDED(ppf2->QueryInterface(IID_IShellFolder, (void**)&psf)))
                                                             {
                                                                 STRRET str;
-                                                                if (SUCCEEDED(psf->GetDisplayNameOf(pidlItem, SHGDN_INFOLDER, &str)))
+                                                                if (SUCCEEDED(psf->GetDisplayNameOf(pidlItem, SHGDN_FORPARSING, &str)))
                                                                 {
                                                                     StrRetToBuf(&str, pidlItem, szItem, MAX_PATH);
 
-                                                                    filepath.append(szPath);
-                                                                    filepath.append(L"\\");
-                                                                    filepath.append(szItem);
+                                                                    filepath.assign(szItem);
 
                                                                     Logger::info(L"Selected file: {}", filepath);
 

--- a/src/modules/peek/PeekViewer/App.cpp
+++ b/src/modules/peek/PeekViewer/App.cpp
@@ -229,14 +229,18 @@ HRESULT App::ParseFileNames()
             // Also does not handle navigating files in icon view in File Explorer
             for (const auto& entry : std::filesystem::directory_iterator(path))
             {
-                m_fileList.emplace_back(ParseFileInfo(entry));
-                    
-                // found the file the user is trying to access
-                if (std::filesystem::equivalent(entry.path(), files[0]))
+                if (FileUtils::IsViewable(entry.path().c_str()))
                 {
-                    m_currentItem = index;
+                    m_fileList.emplace_back(ParseFileInfo(entry));
+
+                    // found the file the user is trying to access
+                    if (std::filesystem::equivalent(entry.path(), files[0]))
+                    {
+                        m_currentItem = index;
+                    }
+
+                    index++;
                 }
-                index++;
             }
         }
         else


### PR DESCRIPTION
- Checking if file is viewable - File is not viewable if it's a hidden system file
- Changed file name retrieval flag to `SHGDN_FORPARSING`. This will get the full file path with extension even if folder settings hide extensions. Also gets the extension of shortcut files (.lnk)
